### PR TITLE
Fixes 'In reply to' fallback, fixing view on Riot.im/Android

### DIFF
--- a/mautrix/client/api/types/event/message.py
+++ b/mautrix/client/api/types/event/message.py
@@ -311,8 +311,8 @@ class MessageUnsigned(BaseUnsigned, SerializableAttrs['MessageUnsigned']):
 
 
 html_reply_fallback_format = ("<mx-reply><blockquote>"
-                              "<a href='https://matrix.to/#/{room_id}/{event_id}'>In reply to</a>"
-                              "<a href='https://matrix.to/#/{sender}'>{displayname}</a>"
+                              "<a href='https://matrix.to/#/{room_id}/{event_id}'>In reply to</a> "
+                              "<a href='https://matrix.to/#/{sender}'>{displayname}</a><br/>"
                               "{content}"
                               "</blockquote></mx-reply>")
 


### PR DESCRIPTION
See
https://matrix.org/docs/spec/client_server/r0.5.0#fallbacks-and-event-representation

Currently, Riot.im/Android does not show replies from maubots well because of this — they are missing the space and newline.

Many thanks.