### PR TITLE
Catch exception when overwriting config

### DIFF
--- a/mautrix/util/config.py
+++ b/mautrix/util/config.py
@@ -8,11 +8,14 @@ from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 from abc import ABC, abstractmethod
 import io
+import logging
 
 yaml = YAML()
 yaml.indent(4)
 
 T = TypeVar('T')
+
+log: logging.Logger = logging.getLogger("mau.util.config")
 
 
 class RecursiveDict(Generic[T]):
@@ -209,5 +212,8 @@ class BaseFileConfig(BaseConfig, ABC):
         return None
 
     def save(self) -> None:
-        with open(self.path, 'w') as stream:
-            yaml.dump(self._data, stream)
+        try:
+            with open(self.path, 'w') as stream:
+                yaml.dump(self._data, stream)
+        except OSError:
+            log.exception(f"Failed to overwrite the config in {self.path}")


### PR DESCRIPTION
In some cases overwriting the config might be impossible, I thought it shouldn't
crash mautrix in such cases but only issue a warning in the logs. The base config
would still be merged in memory so it shouldn't be functionally different.

Also when overwriting, if the base config ever change, those changes will not be
propagated in the user config as older options from the previous base config would
already be present.