### PR TITLE
add pool_pre_ping to sqlalchemy options

### DIFF
--- a/mautrix/bridge/bridge.py
+++ b/mautrix/bridge/bridge.py
@@ -130,7 +130,7 @@ class Bridge(Program, ABC):
     def prepare_db(self) -> None:
         if not sql:
             raise RuntimeError("SQLAlchemy is not installed")
-        self.db = sql.create_engine(self.config["appservice.database"])
+        self.db = sql.create_engine(self.config["appservice.database"], pool_pre_ping=True)
         Base.metadata.bind = self.db
         if not self.db.has_table("alembic_version"):
             self.log.critical("alembic_version table not found. "


### PR DESCRIPTION
Add the pool_pre_ping option to the postgres driver

see https://docs.sqlalchemy.org/en/13/core/pooling.html

This helps sqlalchemy handle database connections that have been closed due to inactivity (or postgres restarting etc).