### PR TITLE
appservice: Send receipts for unjoined rooms

### DIFF
--- a/mautrix/appservice/api/intent.py
+++ b/mautrix/appservice/api/intent.py
@@ -50,7 +50,6 @@ ENSURE_JOINED_METHODS = (
     ClientAPI.get_event, ClientAPI.get_state_event, ClientAPI.get_state,
     ClientAPI.get_joined_members, ClientAPI.get_messages, ClientAPI.send_state_event,
     ClientAPI.send_message_event, ClientAPI.redact,
-    ClientAPI.send_receipt, ClientAPI.set_fully_read_marker,
 )
 
 


### PR DESCRIPTION
Fixes #34

---

As far as I can tell, using this with `mautrix-facebook` doesn't break anything, and lets the bridge bot send delivery receipts for private DM portals without it having to being a member of the portal.

Feel free to discard this if it's based on shaky ground. IMO the CS spec should forbid users sending receipts for rooms they aren't a part of, but for the time being it can be exploited for convenience.